### PR TITLE
feat: export Cluster class

### DIFF
--- a/hclust.d.ts
+++ b/hclust.d.ts
@@ -21,7 +21,7 @@ export interface AgnesOptions<T> {
 //   distanceFunction?: (a: T, b: T) => number;
 // }
 
-export interface Cluster {
+export class Cluster {
   children: Cluster[];
   height: number;
   size: number;

--- a/src/__tests__/cluster.test.js
+++ b/src/__tests__/cluster.test.js
@@ -1,6 +1,5 @@
 import * as data from '../../testData';
-
-import { agnes } from '..';
+import { agnes, Cluster } from '..';
 
 test('size', () => {
   const clust = agnes(data.features1);
@@ -43,4 +42,9 @@ test('traverse, isLeaf and index', () => {
   });
   expect(other).toBe(9);
   expect(leaves).toBe(10);
+});
+
+test('class access', () => {
+  const clust = new Cluster();
+  expect(clust.children).toStrictEqual([]);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,4 @@ export * from './agnes';
 // export * from './birch';
 // export * './cure';
 // export * from './chameleon';
+export { default as Cluster } from './Cluster';


### PR DESCRIPTION
The Cluster class has several methods that are useful with clustering results created independently from the agnes method.

(Alternatively, `Cluster` could be moved to a new `ml-cluster` package and imported here. In my case, I use both the `agnes()` method and the `Cluster` constructor.)